### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,18 +7,18 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SimpleRGB  KEYWORD1
+SimpleRGB	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin  KEYWORD2
-red KEYWORD2
-green KEYWORD2
-blue KEYWORD2
-clear  KEYWORD2
-diff KEYWORD2
+begin	KEYWORD2
+red	KEYWORD2
+green	KEYWORD2
+blue	KEYWORD2
+clear	KEYWORD2
+diff	KEYWORD2
 getRGBColor	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords